### PR TITLE
feat: Refactor AST and introduce WebAssembly compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ A statically typed calculator language written in Haskell with a focus on type s
   - `let` bindings (single and multiple)
   - Lambda expressions with explicit type annotations
   - Partial application & multi-argument functions
-  - Hindley-Milner-style type inference during desugaring
 
 ## Getting Started
 

--- a/calculator.cabal
+++ b/calculator.cabal
@@ -37,6 +37,10 @@ library
       Language.Calculator.CST.Types
       Language.Calculator.CST.Utils
       Language.Calculator.Desugar
+      Language.Calculator.Wasm.CompileEnv
+      Language.Calculator.Wasm.Compiler
+      Language.Calculator.Wasm.Printer
+      Language.Calculator.Wasm.Types
   other-modules:
       Paths_calculator
   hs-source-dirs:
@@ -49,6 +53,7 @@ library
       base >=4.7 && <5
     , containers
     , megaparsec
+    , mtl
     , parser-combinators
     , text
   default-language: GHC2024
@@ -68,6 +73,7 @@ executable calculator-exe
     , calculator
     , containers
     , megaparsec
+    , mtl
     , parser-combinators
     , text
   default-language: GHC2024
@@ -91,6 +97,7 @@ test-suite calculator-test
     , containers
     , hspec
     , megaparsec
+    , mtl
     , parser-combinators
     , text
   default-language: GHC2024

--- a/package.yaml
+++ b/package.yaml
@@ -25,6 +25,7 @@ dependencies:
 - megaparsec
 - parser-combinators
 - containers
+- mtl
 
 ghc-options:
 - -Wall

--- a/src/Language/Calculator/AST/Interpreter.hs
+++ b/src/Language/Calculator/AST/Interpreter.hs
@@ -11,21 +11,21 @@ import Data.Text (unpack)
 -- Main interpreter function
 interpret :: forall t. Env -> Expr t -> Value
 interpret env expr = case expr of
-    ExprLit _ SInt val -> VInt val
-    ExprLit _ SDouble val -> VDouble val
-    ExprLit _ SBool val -> VBool val
-    ExprLit _ SString val -> VString val
-    ExprLit _ STuple _ -> error "Tuple literal not directly supported, use ExprTuple"
-    ExprLit _ SUnit _ -> VUnit
-    ExprLit _ (SFun _ _) _ -> error "Function literal not supported"
+    ExprLit (LitExpr {litBase = ExprBase _ SInt, litValue = val}) -> VInt val
+    ExprLit (LitExpr {litBase = ExprBase _ SDouble, litValue = val}) -> VDouble val
+    ExprLit (LitExpr {litBase = ExprBase _ SBool, litValue = val}) -> VBool val
+    ExprLit (LitExpr {litBase = ExprBase _ SString, litValue = val}) -> VString val
+    ExprLit (LitExpr {litBase = ExprBase _ STuple}) -> error "Tuple literal not directly supported, use ExprTuple"
+    ExprLit (LitExpr {litBase = ExprBase _ SUnit}) -> VUnit
+    ExprLit (LitExpr {litBase = ExprBase _ (SFun _ _)}) -> error "Function literal not supported"
     
-    ExprIdent _ name -> case lookupEnv name env of
+    ExprIdent (IdentExpr {identName = name}) -> case lookupEnv name env of
         Just val -> val
         Nothing -> error $ "Unbound variable: " ++ unpack name
     
-    ExprTuple _ exprs -> VTuple $ map (\(Exists e) -> interpret env e) exprs
+    ExprTuple (TupleExpr {tupleElems = exprs}) -> VTuple $ map (\(Exists e) -> interpret env e) exprs
     
-    ExprUnary _ op e -> case (op, interpret env e) of
+    ExprUnary (UnaryExpr {unaryOp = op, unaryExpr = e}) -> case (op, interpret env e) of
         (NotBool, VBool b) -> VBool $ not b
         (PosDouble, VDouble d) -> VDouble d
         (NegDouble, VDouble d) -> VDouble $ -d
@@ -33,7 +33,7 @@ interpret env expr = case expr of
         (NegInt, VInt i) -> VInt $ -i
         _ -> error "Invalid unary operation or type mismatch"
     
-    ExprBinary _ op e1 e2 -> case (op, interpret env e1, interpret env e2) of
+    ExprBinary (BinaryExpr {binaryOp = op, binaryLeft = e1, binaryRight = e2}) -> case (op, interpret env e1, interpret env e2) of
         (AddDouble, VDouble d1, VDouble d2) -> VDouble (d1 + d2)
         (SubDouble, VDouble d1, VDouble d2) -> VDouble (d1 - d2)
         (MulDouble, VDouble d1, VDouble d2) -> VDouble (d1 * d2)
@@ -54,7 +54,7 @@ interpret env expr = case expr of
         (NeString, VString s1, VString s2) -> VBool (s1 == s2)
         _ -> error "Invalid binary operation or type mismatch"
 
-    ExprApp _ f a ->
+    ExprApp (AppExpr {appFun = f, appArg = a}) ->
         let funVal = interpret env f
             argVal = interpret env a
         in case funVal of
@@ -63,30 +63,30 @@ interpret env expr = case expr of
                 in interpret newEnv body
             _ -> error "Attempted to apply a non-function value"
 
-    ExprIf _ cond thenExpr elseExpr -> case interpret env cond of
+    ExprIf (IfExpr {ifCond = cond, ifThen = thenExpr, ifElse = elseExpr}) -> case interpret env cond of
         VBool True -> interpret env thenExpr
         VBool False -> interpret env elseExpr
         _ -> error "If condition must be a boolean"
 
-    ExprWhile _ cond body -> 
+    ExprWhile (WhileExpr {whileCond = cond, whileBody = body}) -> 
         let loop () = case interpret env cond of
                          VBool True -> interpret env body `seq` loop ()
                          VBool False -> VUnit
                          _ -> error "While condition must be a boolean"
         in loop ()
 
-    ExprBlock _ exprs -> 
+    ExprBlock (BlockExpr {blockElems = exprs}) -> 
         let evalBlock :: [Exists Expr] -> Env -> Value
             evalBlock [] _ = VUnit
             evalBlock [Exists e] env' = interpret env' e
             evalBlock (Exists e:es) env' = interpret env' e `seq` evalBlock es env'
         in evalBlock exprs env
 
-    ExprLet _ bindings body ->
+    ExprLet (LetExpr {letBindings = bindings, letBody = body}) ->
         let newBindings = map (\(name, Exists value) -> (name, interpret env value)) bindings
             newEnv = extendEnv newBindings env
         in interpret newEnv body
 
-    ExprLambda _ param _ body -> VClosure param body env
+    ExprLambda (LambdaExpr {lambdaParam = param, lambdaBody = body}) -> VClosure param body env
     
-    ExprUnit -> VUnit
+    ExprUnit (UnitExpr {}) -> VUnit

--- a/src/Language/Calculator/AST/Printer.hs
+++ b/src/Language/Calculator/AST/Printer.hs
@@ -11,37 +11,37 @@ pprintExpr prefix isLast (Exists e) =
         then (end, prefix <> space)
         else (start, prefix <> vertical)
     in case e of
-    (ExprLit _ _ val) -> putStrLn $ prefix <> sign <> show val
-    (ExprIdent _ i) -> putStrLn $ prefix <> sign <> unpack i
-    (ExprTuple _ es) ->
+    ExprLit (LitExpr {litValue = val}) -> putStrLn $ prefix <> sign <> show val
+    ExprIdent (IdentExpr {identName = i}) -> putStrLn $ prefix <> sign <> unpack i
+    ExprTuple (TupleExpr {tupleElems = es}) ->
         putStrLn (prefix <> sign <> "()") >> go pprintExpr childPrefix es
-    (ExprUnary _ op e1) ->
+    ExprUnary (UnaryExpr {unaryOp = op, unaryExpr = e1}) ->
         putStrLn (prefix <> sign <> show op) >> pprintExpr childPrefix True (Exists e1)
-    (ExprBinary _ op e1 e2) ->
+    ExprBinary (BinaryExpr {binaryOp = op, binaryLeft = e1, binaryRight = e2}) ->
         putStrLn (prefix <> sign <> show op) >> 
         pprintExpr childPrefix False (Exists e1) >> 
         pprintExpr childPrefix True (Exists e2)
-    (ExprApp _ f a) ->
+    ExprApp (AppExpr {appFun = f, appArg = a}) ->
         putStrLn (prefix <> sign <> "APP") >>
         pprintExpr childPrefix False (Exists f) >>
         pprintExpr childPrefix True (Exists a)
-    (ExprIf _ cond thenExpr elseExpr) ->
+    ExprIf (IfExpr {ifCond = cond, ifThen = thenExpr, ifElse = elseExpr}) ->
         putStrLn (prefix <> sign <> "IF") >>
         pprintExpr childPrefix False (Exists cond) >>
         putStrLn (childPrefix <> start <> "THEN") >>
         pprintExpr (childPrefix <> vertical) True (Exists thenExpr) >>
         putStrLn (childPrefix <> end <> "ELSE") >>
         pprintExpr (childPrefix <> space) True (Exists elseExpr)
-    (ExprWhile _ cond body) ->
+    ExprWhile (WhileExpr {whileCond = cond, whileBody = body}) ->
         putStrLn (prefix <> sign <> "WHILE") >>
         pprintExpr childPrefix False (Exists cond) >>
         putStrLn (childPrefix <> end <> "DO") >>
         pprintExpr (childPrefix <> space) True (Exists body)
-    (ExprBlock _ es) ->
+    ExprBlock (BlockExpr {blockElems = es}) ->
         putStrLn (prefix <> sign <> "BLOCK") >> go pprintExpr childPrefix es
-    ExprUnit ->
+    ExprUnit (UnitExpr {}) ->
         putStrLn $ prefix <> sign <> "UNIT"
-    (ExprLet _ bindings body) -> do
+    ExprLet (LetExpr {letBindings = bindings, letBody = body}) -> do
         putStrLn (prefix <> sign <> "LET")
         let printBinding (name, value) = do
                 putStrLn (childPrefix <> start <> unpack name)
@@ -49,7 +49,7 @@ pprintExpr prefix isLast (Exists e) =
         mapM_ printBinding bindings
         putStrLn (childPrefix <> end <> "IN")
         pprintExpr (childPrefix <> space) True (Exists body)
-    (ExprLambda _ param ty body) ->
+    ExprLambda (LambdaExpr {lambdaParam = param, lambdaParamType = ty, lambdaBody = body}) ->
         putStrLn (prefix <> sign <> "LAMBDA " <> unpack param <> " : " <> show ty) >>
         pprintExpr childPrefix True (Exists body)
 

--- a/src/Language/Calculator/CST/Parser.hs
+++ b/src/Language/Calculator/CST/Parser.hs
@@ -86,7 +86,7 @@ infixOpWithSource opToken leftExpr rightExpr =
 -- Helper for Prefix operators to capture SourceToken ()
 prefixOpWithSource :: SourceToken Operator -> Expr -> Expr
 prefixOpWithSource opToken e =
-    let start = (tokRange opToken).srcStart
+    let start = opToken.tokRange.srcStart
         end = (getExprRange e).srcEnd
         range = SourceRange start end
     in ExprUnary (SourceToken range ()) opToken e

--- a/src/Language/Calculator/Desugar.hs
+++ b/src/Language/Calculator/Desugar.hs
@@ -6,37 +6,37 @@ import Data.Text qualified as Text
 import Data.Type.Equality
 import Language.Calculator.AST.Types as AST
 import Language.Calculator.CST.Types qualified as CST
-import Language.Calculator.Common.Types (SourceRange (..), SourceToken (..))
+import Language.Calculator.Common.Types (SourceToken (..))
 
 -- The main desugaring function that converts CST to a type-checked AST.
 desugar :: TypeEnv -> CST.Expr -> Either AST.TypeError AST.TypeExpr
 desugar env cstExpr = do
   let sourceToken = SourceToken (CST.getExprRange cstExpr) ()
   case cstExpr of
-    CST.ExprInt t -> Right $ AST.TypeExpr AST.SInt (AST.ExprLit sourceToken AST.SInt t.tokValue)
-    CST.ExprDouble t -> Right $ AST.TypeExpr AST.SDouble (AST.ExprLit sourceToken AST.SDouble t.tokValue)
-    CST.ExprBool t -> Right $ AST.TypeExpr AST.SBool (AST.ExprLit sourceToken AST.SBool t.tokValue)
-    CST.ExprString t -> Right $ AST.TypeExpr AST.SString (AST.ExprLit sourceToken AST.SString t.tokValue)
+    CST.ExprInt t -> Right $ AST.TypeExpr AST.SInt (AST.ExprLit (AST.LitExpr {AST.litBase = AST.ExprBase sourceToken AST.SInt, AST.litValue = t.tokValue}))
+    CST.ExprDouble t -> Right $ AST.TypeExpr AST.SDouble (AST.ExprLit (AST.LitExpr {AST.litBase = AST.ExprBase sourceToken AST.SDouble, AST.litValue = t.tokValue}))
+    CST.ExprBool t -> Right $ AST.TypeExpr AST.SBool (AST.ExprLit (AST.LitExpr {AST.litBase = AST.ExprBase sourceToken AST.SBool, AST.litValue = t.tokValue}))
+    CST.ExprString t -> Right $ AST.TypeExpr AST.SString (AST.ExprLit (AST.LitExpr {AST.litBase = AST.ExprBase sourceToken AST.SString, AST.litValue = t.tokValue}))
     CST.ExprIdent t ->
       let name = t.tokValue
        in case Map.lookup name env of
             Nothing -> Left $ AST.UnboundVariable t.tokRange name
-            Just (AST.TypeExpr AST.SInt _) -> Right $ AST.TypeExpr AST.SInt (AST.ExprIdent sourceToken name)
-            Just (AST.TypeExpr AST.SDouble _) -> Right $ AST.TypeExpr AST.SDouble (AST.ExprIdent sourceToken name)
-            Just (AST.TypeExpr AST.SBool _) -> Right $ AST.TypeExpr AST.SBool (AST.ExprIdent sourceToken name)
-            Just (AST.TypeExpr AST.SString _) -> Right $ AST.TypeExpr AST.SString (AST.ExprIdent sourceToken name)
-            Just (AST.TypeExpr AST.STuple _) -> Right $ AST.TypeExpr AST.STuple (AST.ExprIdent sourceToken name)
-            Just (AST.TypeExpr AST.SUnit _) -> Right $ AST.TypeExpr AST.SUnit (AST.ExprIdent sourceToken name)
-            Just (AST.TypeExpr (AST.SFun paramTy retTy) _) -> Right $ AST.TypeExpr (AST.SFun paramTy retTy) (AST.ExprIdent sourceToken name)
+            Just (AST.TypeExpr AST.SInt _) -> Right $ AST.TypeExpr AST.SInt (AST.ExprIdent (AST.IdentExpr {AST.identBase = AST.ExprBase sourceToken AST.SInt, AST.identName = name}))
+            Just (AST.TypeExpr AST.SDouble _) -> Right $ AST.TypeExpr AST.SDouble (AST.ExprIdent (AST.IdentExpr {AST.identBase = AST.ExprBase sourceToken AST.SDouble, AST.identName = name}))
+            Just (AST.TypeExpr AST.SBool _) -> Right $ AST.TypeExpr AST.SBool (AST.ExprIdent (AST.IdentExpr {AST.identBase = AST.ExprBase sourceToken AST.SBool, AST.identName = name}))
+            Just (AST.TypeExpr AST.SString _) -> Right $ AST.TypeExpr AST.SString (AST.ExprIdent (AST.IdentExpr {AST.identBase = AST.ExprBase sourceToken AST.SString, AST.identName = name}))
+            Just (AST.TypeExpr AST.STuple _) -> Right $ AST.TypeExpr AST.STuple (AST.ExprIdent (AST.IdentExpr {AST.identBase = AST.ExprBase sourceToken AST.STuple, AST.identName = name}))
+            Just (AST.TypeExpr AST.SUnit _) -> Right $ AST.TypeExpr AST.SUnit (AST.ExprIdent (AST.IdentExpr {AST.identBase = AST.ExprBase sourceToken AST.SUnit, AST.identName = name}))
+            Just (AST.TypeExpr (AST.SFun paramTy retTy) _) -> Right $ AST.TypeExpr (AST.SFun paramTy retTy) (AST.ExprIdent (AST.IdentExpr {AST.identBase = AST.ExprBase sourceToken (AST.SFun paramTy retTy), AST.identName = name}))
     CST.ExprUnary _ opToken cstE -> do
       AST.TypeExpr sty e <- desugar env cstE
       let op = opToken.tokValue
       case (op, sty) of
-        (CST.OpNot, AST.SBool) -> Right $ AST.TypeExpr AST.SBool (AST.ExprUnary sourceToken AST.NotBool e)
-        (CST.OpPlus, AST.SDouble) -> Right $ AST.TypeExpr AST.SDouble (AST.ExprUnary sourceToken AST.PosDouble e)
-        (CST.OpMinus, AST.SDouble) -> Right $ AST.TypeExpr AST.SDouble (AST.ExprUnary sourceToken AST.NegDouble e)
-        (CST.OpPlus, AST.SInt) -> Right $ AST.TypeExpr AST.SInt (AST.ExprUnary sourceToken AST.PosInt e)
-        (CST.OpMinus, AST.SInt) -> Right $ AST.TypeExpr AST.SInt (AST.ExprUnary sourceToken AST.NegInt e)
+        (CST.OpNot, AST.SBool) -> Right $ AST.TypeExpr AST.SBool (AST.ExprUnary (AST.UnaryExpr {AST.unaryBase = AST.ExprBase sourceToken AST.SBool, AST.unaryOp = AST.NotBool, AST.unaryExpr = e}))
+        (CST.OpPlus, AST.SDouble) -> Right $ AST.TypeExpr AST.SDouble (AST.ExprUnary (AST.UnaryExpr {AST.unaryBase = AST.ExprBase sourceToken AST.SDouble, AST.unaryOp = AST.PosDouble, AST.unaryExpr = e}))
+        (CST.OpMinus, AST.SDouble) -> Right $ AST.TypeExpr AST.SDouble (AST.ExprUnary (AST.UnaryExpr {AST.unaryBase = AST.ExprBase sourceToken AST.SDouble, AST.unaryOp = AST.NegDouble, AST.unaryExpr = e}))
+        (CST.OpPlus, AST.SInt) -> Right $ AST.TypeExpr AST.SInt (AST.ExprUnary (AST.UnaryExpr {AST.unaryBase = AST.ExprBase sourceToken AST.SInt, AST.unaryOp = AST.PosInt, AST.unaryExpr = e}))
+        (CST.OpMinus, AST.SInt) -> Right $ AST.TypeExpr AST.SInt (AST.ExprUnary (AST.UnaryExpr {AST.unaryBase = AST.ExprBase sourceToken AST.SInt, AST.unaryOp = AST.NegInt, AST.unaryExpr = e}))
         _ -> Left $ AST.OpMismatch opToken.tokRange (CST.opToText op) (AST.Exists sty)
     CST.ExprBinary _ opToken cstE1 cstE2 -> do
       AST.TypeExpr sty1 e1 <- desugar env cstE1
@@ -45,24 +45,24 @@ desugar env cstExpr = do
       case testEquality sty1 sty2 of
         Nothing -> Left $ AST.TypeMismatch opToken.tokRange (AST.Exists sty1) (AST.Exists sty2)
         Just Refl -> case (op, sty1) of
-          (CST.OpPlus, AST.SInt) -> Right $ AST.TypeExpr AST.SInt (AST.ExprBinary sourceToken AST.AddInt e1 e2)
-          (CST.OpPlus, AST.SDouble) -> Right $ AST.TypeExpr AST.SDouble (AST.ExprBinary sourceToken AST.AddDouble e1 e2)
-          (CST.OpMinus, AST.SInt) -> Right $ AST.TypeExpr AST.SInt (AST.ExprBinary sourceToken AST.SubInt e1 e2)
-          (CST.OpMinus, AST.SDouble) -> Right $ AST.TypeExpr AST.SDouble (AST.ExprBinary sourceToken AST.SubDouble e1 e2)
-          (CST.OpMultiply, AST.SInt) -> Right $ AST.TypeExpr AST.SInt (AST.ExprBinary sourceToken AST.MulInt e1 e2)
-          (CST.OpMultiply, AST.SDouble) -> Right $ AST.TypeExpr AST.SDouble (AST.ExprBinary sourceToken AST.MulDouble e1 e2)
-          (CST.OpDivide, AST.SInt) -> Right $ AST.TypeExpr AST.SInt (AST.ExprBinary sourceToken AST.DivInt e1 e2)
-          (CST.OpDivide, AST.SDouble) -> Right $ AST.TypeExpr AST.SDouble (AST.ExprBinary sourceToken AST.DivDouble e1 e2)
-          (CST.OpEqual, AST.SInt) -> Right $ AST.TypeExpr AST.SBool (AST.ExprBinary sourceToken AST.EqInt e1 e2)
-          (CST.OpEqual, AST.SDouble) -> Right $ AST.TypeExpr AST.SBool (AST.ExprBinary sourceToken AST.EqDouble e1 e2)
-          (CST.OpEqual, AST.SBool) -> Right $ AST.TypeExpr AST.SBool (AST.ExprBinary sourceToken AST.EqBool e1 e2)
-          (CST.OpEqual, AST.SString) -> Right $ AST.TypeExpr AST.SBool (AST.ExprBinary sourceToken AST.EqString e1 e2)
-          (CST.OpNotEqual, AST.SInt) -> Right $ AST.TypeExpr AST.SBool (AST.ExprBinary sourceToken AST.NeInt e1 e2)
-          (CST.OpNotEqual, AST.SDouble) -> Right $ AST.TypeExpr AST.SBool (AST.ExprBinary sourceToken AST.NeDouble e1 e2)
-          (CST.OpNotEqual, AST.SBool) -> Right $ AST.TypeExpr AST.SBool (AST.ExprBinary sourceToken AST.NeBool e1 e2)
-          (CST.OpNotEqual, AST.SString) -> Right $ AST.TypeExpr AST.SBool (AST.ExprBinary sourceToken AST.NeString e1 e2)
-          (CST.OpAnd, AST.SBool) -> Right $ AST.TypeExpr AST.SBool (AST.ExprBinary sourceToken AST.AndBool e1 e2)
-          (CST.OpOr, AST.SBool) -> Right $ AST.TypeExpr AST.SBool (AST.ExprBinary sourceToken AST.OrBool e1 e2)
+          (CST.OpPlus, AST.SInt) -> Right $ AST.TypeExpr AST.SInt (AST.ExprBinary (AST.BinaryExpr {AST.binaryBase = AST.ExprBase sourceToken AST.SInt, AST.binaryOp = AST.AddInt, AST.binaryLeft = e1, AST.binaryRight = e2}))
+          (CST.OpPlus, AST.SDouble) -> Right $ AST.TypeExpr AST.SDouble (AST.ExprBinary (AST.BinaryExpr {AST.binaryBase = AST.ExprBase sourceToken AST.SDouble, AST.binaryOp = AST.AddDouble, AST.binaryLeft = e1, AST.binaryRight = e2}))
+          (CST.OpMinus, AST.SInt) -> Right $ AST.TypeExpr AST.SInt (AST.ExprBinary (AST.BinaryExpr {AST.binaryBase = AST.ExprBase sourceToken AST.SInt, AST.binaryOp = AST.SubInt, AST.binaryLeft = e1, AST.binaryRight = e2}))
+          (CST.OpMinus, AST.SDouble) -> Right $ AST.TypeExpr AST.SDouble (AST.ExprBinary (AST.BinaryExpr {AST.binaryBase = AST.ExprBase sourceToken AST.SDouble, AST.binaryOp = AST.SubDouble, AST.binaryLeft = e1, AST.binaryRight = e2}))
+          (CST.OpMultiply, AST.SInt) -> Right $ AST.TypeExpr AST.SInt (AST.ExprBinary (AST.BinaryExpr {AST.binaryBase = AST.ExprBase sourceToken AST.SInt, AST.binaryOp = AST.MulInt, AST.binaryLeft = e1, AST.binaryRight = e2}))
+          (CST.OpMultiply, AST.SDouble) -> Right $ AST.TypeExpr AST.SDouble (AST.ExprBinary (AST.BinaryExpr {AST.binaryBase = AST.ExprBase sourceToken AST.SDouble, AST.binaryOp = AST.MulDouble, AST.binaryLeft = e1, AST.binaryRight = e2}))
+          (CST.OpDivide, AST.SInt) -> Right $ AST.TypeExpr AST.SInt (AST.ExprBinary (AST.BinaryExpr {AST.binaryBase = AST.ExprBase sourceToken AST.SInt, AST.binaryOp = AST.DivInt, AST.binaryLeft = e1, AST.binaryRight = e2}))
+          (CST.OpDivide, AST.SDouble) -> Right $ AST.TypeExpr AST.SDouble (AST.ExprBinary (AST.BinaryExpr {AST.binaryBase = AST.ExprBase sourceToken AST.SDouble, AST.binaryOp = AST.DivDouble, AST.binaryLeft = e1, AST.binaryRight = e2}))
+          (CST.OpEqual, AST.SInt) -> Right $ AST.TypeExpr AST.SBool (AST.ExprBinary (AST.BinaryExpr {AST.binaryBase = AST.ExprBase sourceToken AST.SBool, AST.binaryOp = AST.EqInt, AST.binaryLeft = e1, AST.binaryRight = e2}))
+          (CST.OpEqual, AST.SDouble) -> Right $ AST.TypeExpr AST.SBool (AST.ExprBinary (AST.BinaryExpr {AST.binaryBase = AST.ExprBase sourceToken AST.SBool, AST.binaryOp = AST.EqDouble, AST.binaryLeft = e1, AST.binaryRight = e2}))
+          (CST.OpEqual, AST.SBool) -> Right $ AST.TypeExpr AST.SBool (AST.ExprBinary (AST.BinaryExpr {AST.binaryBase = AST.ExprBase sourceToken AST.SBool, AST.binaryOp = AST.EqBool, AST.binaryLeft = e1, AST.binaryRight = e2}))
+          (CST.OpEqual, AST.SString) -> Right $ AST.TypeExpr AST.SBool (AST.ExprBinary (AST.BinaryExpr {AST.binaryBase = AST.ExprBase sourceToken AST.SBool, AST.binaryOp = AST.EqString, AST.binaryLeft = e1, AST.binaryRight = e2}))
+          (CST.OpNotEqual, AST.SInt) -> Right $ AST.TypeExpr AST.SBool (AST.ExprBinary (AST.BinaryExpr {AST.binaryBase = AST.ExprBase sourceToken AST.SBool, AST.binaryOp = AST.NeInt, AST.binaryLeft = e1, AST.binaryRight = e2}))
+          (CST.OpNotEqual, AST.SDouble) -> Right $ AST.TypeExpr AST.SBool (AST.ExprBinary (AST.BinaryExpr {AST.binaryBase = AST.ExprBase sourceToken AST.SBool, AST.binaryOp = AST.NeDouble, AST.binaryLeft = e1, AST.binaryRight = e2}))
+          (CST.OpNotEqual, AST.SBool) -> Right $ AST.TypeExpr AST.SBool (AST.ExprBinary (AST.BinaryExpr {AST.binaryBase = AST.ExprBase sourceToken AST.SBool, AST.binaryOp = AST.NeBool, AST.binaryLeft = e1, AST.binaryRight = e2}))
+          (CST.OpNotEqual, AST.SString) -> Right $ AST.TypeExpr AST.SBool (AST.ExprBinary (AST.BinaryExpr {AST.binaryBase = AST.ExprBase sourceToken AST.SBool, AST.binaryOp = AST.NeString, AST.binaryLeft = e1, AST.binaryRight = e2}))
+          (CST.OpAnd, AST.SBool) -> Right $ AST.TypeExpr AST.SBool (AST.ExprBinary (AST.BinaryExpr {AST.binaryBase = AST.ExprBase sourceToken AST.SBool, AST.binaryOp = AST.AndBool, AST.binaryLeft = e1, AST.binaryRight = e2}))
+          (CST.OpOr, AST.SBool) -> Right $ AST.TypeExpr AST.SBool (AST.ExprBinary (AST.BinaryExpr {AST.binaryBase = AST.ExprBase sourceToken AST.SBool, AST.binaryOp = AST.OrBool, AST.binaryLeft = e1, AST.binaryRight = e2}))
           _ -> Left $ AST.OpMismatch opToken.tokRange (CST.opToText op) (AST.Exists sty1)
 
     -- If-else statement
@@ -74,7 +74,7 @@ desugar env cstExpr = do
           AST.TypeExpr elseTy else' <- desugar env elseExpr
           case testEquality thenTy elseTy of
             Nothing -> Left $ AST.TypeMismatch (CST.getExprRange cstExpr) (AST.Exists thenTy) (AST.Exists elseTy)
-            Just Refl -> Right $ AST.TypeExpr thenTy (AST.ExprIf sourceToken cond' then' else')
+            Just Refl -> Right $ AST.TypeExpr thenTy (AST.ExprIf (AST.IfExpr {AST.ifBase = AST.ExprBase sourceToken thenTy, AST.ifCond = cond', AST.ifThen = then', AST.ifElse = else'}))
         _ -> Left $ AST.OpMismatch (CST.getExprRange cond) "if condition" (AST.Exists condTy)
 
     -- While loop
@@ -84,7 +84,7 @@ desugar env cstExpr = do
         AST.SBool -> do
           AST.TypeExpr bodyTy body' <- desugar env body
           case bodyTy of
-            AST.SUnit -> Right $ AST.TypeExpr AST.SUnit (AST.ExprWhile sourceToken cond' body')
+            AST.SUnit -> Right $ AST.TypeExpr AST.SUnit (AST.ExprWhile (AST.WhileExpr {AST.whileBase = AST.ExprBase sourceToken AST.SUnit, AST.whileCond = cond', AST.whileBody = body'}))
             _ -> Left $ AST.OpMismatch (CST.getExprRange body) "while body" (AST.Exists bodyTy)
         _ -> Left $ AST.OpMismatch (CST.getExprRange cond) "while condition" (AST.Exists condTy)
 
@@ -92,14 +92,14 @@ desugar env cstExpr = do
     CST.ExprBlock _ exprs -> do
       desugaredExprs <- mapM (desugar env) exprs
       case desugaredExprs of
-        [] -> Right $ AST.TypeExpr AST.SUnit AST.ExprUnit
+        [] -> Right $ AST.TypeExpr AST.SUnit (AST.ExprUnit (AST.UnitExpr {AST.unitBase = AST.ExprBase sourceToken AST.SUnit}))
         [AST.TypeExpr ty e] -> Right $ AST.TypeExpr ty e
-        _ -> Right $ AST.TypeExpr AST.SUnit (AST.ExprBlock sourceToken (map (\(AST.TypeExpr _ e) -> AST.Exists e) desugaredExprs))
+        _ -> Right $ AST.TypeExpr AST.SUnit (AST.ExprBlock (AST.BlockExpr {AST.blockBase = AST.ExprBase sourceToken AST.SUnit, AST.blockElems = map (\(AST.TypeExpr _ e) -> AST.Exists e) desugaredExprs}))
 
     -- Tuple expression
     CST.ExprTuple _ exprs -> do
       desugaredExprs <- mapM (desugar env) exprs
-      Right $ AST.TypeExpr AST.STuple (AST.ExprTuple sourceToken (map (\(AST.TypeExpr _ e) -> AST.Exists e) desugaredExprs))
+      Right $ AST.TypeExpr AST.STuple (AST.ExprTuple (AST.TupleExpr {AST.tupleBase = AST.ExprBase sourceToken AST.STuple, AST.tupleElems = map (\(AST.TypeExpr _ e) -> AST.Exists e) desugaredExprs}))
 
     -- Function application
     CST.ExprApp _ fToken args -> do
@@ -121,7 +121,7 @@ desugar env cstExpr = do
                         appEnd = (AST.getExprRange argAst).srcEnd
                         appRange = SourceRange appStart appEnd
                         appSourceToken = SourceToken appRange ()
-                     in Right $ AST.TypeExpr retTy (AST.ExprApp appSourceToken fAst' argAst)
+                     in Right $ AST.TypeExpr retTy (AST.ExprApp (AST.AppExpr {AST.appBase = AST.ExprBase appSourceToken retTy, AST.appFun = fAst', AST.appArg = argAst}))
               _ -> Left $ AST.NotAFunction (AST.getExprRange fAst') (Text.pack $ show fAst')
       -- Start with the desugared function, and fold the arguments onto it
       foldM applyArg (AST.TypeExpr fTy fAst) args
@@ -147,7 +147,7 @@ desugar env cstExpr = do
       -- Convert bindings to AST format
       let astBindings = map (\(name, AST.TypeExpr _ ast) -> (name, AST.Exists ast)) desugaredBindings
 
-      Right $ AST.TypeExpr bodyTy (AST.ExprLet sourceToken astBindings bodyAst)
+      Right $ AST.TypeExpr bodyTy (AST.ExprLet (AST.LetExpr {AST.letBase = AST.ExprBase sourceToken bodyTy, AST.letBindings = astBindings, AST.letBody = bodyAst}))
 
     -- Lambda expression
     CST.ExprLambda _ params body -> do
@@ -172,7 +172,7 @@ desugar env cstExpr = do
           params -- Store the whole token, not just its value.
 
       -- Create the new environment for the lambda body
-      let newEnv = foldl (\e (tok, AST.Exists ty) -> Map.insert tok.tokValue (AST.TypeExpr ty (AST.ExprIdent (SourceToken tok.tokRange ()) tok.tokValue)) e) env paramList
+      let newEnv = foldl (\e (tok, AST.Exists ty) -> Map.insert tok.tokValue (AST.TypeExpr ty (AST.ExprIdent (AST.IdentExpr {AST.identBase = AST.ExprBase (SourceToken tok.tokRange ()) ty, AST.identName = tok.tokValue}))) e) env paramList
 
       -- Desugar the body with the new environment
       AST.TypeExpr bodyTy bodyAst <- desugar newEnv body
@@ -183,6 +183,6 @@ desugar env cstExpr = do
                 lambdaEnd = AST.getExprRange accExpr
                 combinedRange = SourceRange lambdaStart.srcStart lambdaEnd.srcEnd
                 lambdaSourceToken = SourceToken combinedRange ()
-             in AST.TypeExpr (AST.SFun paramTy accTy) (AST.ExprLambda lambdaSourceToken tok.tokValue paramTy accExpr)
+             in AST.TypeExpr (AST.SFun paramTy accTy) (AST.ExprLambda (AST.LambdaExpr {AST.lambdaBase = AST.ExprBase lambdaSourceToken (AST.SFun paramTy accTy), AST.lambdaParam = tok.tokValue, AST.lambdaParamType = paramTy, AST.lambdaBody = accExpr}))
 
       Right $ foldr buildLambda (AST.TypeExpr bodyTy bodyAst) paramList

--- a/src/Language/Calculator/Wasm/CompileEnv.hs
+++ b/src/Language/Calculator/Wasm/CompileEnv.hs
@@ -1,0 +1,48 @@
+module Language.Calculator.Wasm.CompileEnv
+  ( CompileEnv (..),
+    initialCompileEnv,
+    extractFuncLocals,
+    addFunctionTypeSignature,
+  )
+where
+
+import Data.Map qualified as Map
+import Data.Text (Text, pack)
+import Language.Calculator.Wasm.Types (WatType (..), WatTypeSignature (..))
+
+-- | Represents the compilation environment
+data CompileEnv = CompileEnv
+  { localMap :: Map.Map Text (Either WatType Text),
+    typeSignatures :: Map.Map WatTypeSignature Text -- Stores type signatures mapped to their aliases.
+  }
+
+-- | Initial compilation environment
+initialCompileEnv :: CompileEnv
+initialCompileEnv =
+  CompileEnv
+    { localMap = Map.empty,
+      typeSignatures = Map.empty -- Initialize as empty Map.Map WatTypeSignature Text
+    }
+
+-- | Helper to extract actual local variables from the localMap
+extractFuncLocals :: Map.Map Text (Either WatType Text) -> [(Text, WatType)]
+extractFuncLocals =
+  Map.foldrWithKey
+    (\name val acc ->
+        case val of
+          Left watTy -> (name, watTy) : acc
+          Right _ -> acc
+    )
+    []
+
+-- | Helper to add a function type signature to the environment and get its alias
+addFunctionTypeSignature :: CompileEnv -> Text -> WatTypeSignature -> (Text, CompileEnv)
+addFunctionTypeSignature env funcName sig =
+  case Map.lookup sig env.typeSignatures of
+    Just alias -> (alias, env)
+    Nothing ->
+      let paramTypes = mconcat (pack . show <$> sig.sigParams)
+          newAlias = "type_" <> funcName <> "_" <> paramTypes
+          updatedTypeSignatures = Map.insert sig newAlias env.typeSignatures
+          newEnv = env {typeSignatures = updatedTypeSignatures}
+       in (newAlias, newEnv) 

--- a/src/Language/Calculator/Wasm/Compiler.hs
+++ b/src/Language/Calculator/Wasm/Compiler.hs
@@ -1,0 +1,167 @@
+{-# LANGUAGE MultiWayIf #-}
+
+module Language.Calculator.Wasm.Compiler
+  ( compileToWasm,
+  )
+where
+
+import Control.Monad.RWS.Strict
+import Data.Map qualified as Map
+import Data.Text (Text, pack)
+import Data.Type.Equality (testEquality, (:~:) (Refl))
+import Language.Calculator.AST.Types (AppExpr (..), BinaryExpr (..), Exists (..), Expr (..), IdentExpr (..), IfExpr (..), LambdaExpr (..), LetExpr (..), LitExpr (..), Op (..), TermT (..), exprType, getExprType)
+import Language.Calculator.Wasm.CompileEnv (CompileEnv (..), addFunctionTypeSignature, extractFuncLocals, initialCompileEnv)
+import Language.Calculator.Wasm.Types (WatExpr (..), WatFunction (..), WatLit (..), WatModule (..), WatOp (..), WatType (..), WatTypeSignature (..))
+
+-- | Type alias for the Compiler Monad
+type CompilerM = RWS () [WatFunction] CompileEnv
+
+-- | Converts a Calculator TermT to a WAT type
+termTToWatType :: Exists TermT -> WatType
+termTToWatType (Exists SInt) = I32
+termTToWatType (Exists SDouble) = F64
+termTToWatType (Exists SBool) = I32 -- Booleans are typically represented as I32 (0 for false, 1 for true) in WASM
+termTToWatType (Exists (SFun _ _)) = WatTypeRef "func"
+termTToWatType (Exists SUnit) = Void -- Unit type, no value returned
+termTToWatType _ = error "Unsupported Calculator TermT for WASM conversion"
+
+-- | Helper function to compile a single let binding within an ExprLet
+compileLetBinding :: (Text, Exists Expr) -> CompilerM ([WatExpr])
+compileLetBinding (name, Exists expr) =
+  do
+    valExprs <- compileExpr (Exists expr)
+    currentEnv <- get
+    let bindingWatType = termTToWatType (getExprType (Exists expr))
+    let updatedLocalMap = Map.insert name (Left bindingWatType) currentEnv.localMap
+    let envAfterLocal = currentEnv {localMap = updatedLocalMap}
+    case getExprType (Exists expr) of
+      Exists (SFun _ _) -> do
+        -- For functions, we update the local map with the function name directly.
+        -- No WAT expressions are generated for the binding itself; the function is available by name.
+        case valExprs of
+            [WatRef fnName] -> put (envAfterLocal {localMap = Map.insert name (Right fnName) envAfterLocal.localMap})
+            _ -> error "Expected a single WatRef for function binding"
+        return [] -- Return empty list for function bindings
+      _ -> do
+        put envAfterLocal
+        return (valExprs ++ [WatLocalSet name bindingWatType])
+
+-- | Compiles a single expression to WAT expressions and accumulates functions
+compileExpr :: Exists Expr -> CompilerM [WatExpr]
+compileExpr (Exists (ExprLit (LitExpr base val))) =
+  if
+    | Just Refl <- testEquality base.exprType SInt -> return [WatConst (LitI32 val)]
+    | Just Refl <- testEquality base.exprType SDouble -> return [WatConst (LitF64 val)]
+    | Just Refl <- testEquality base.exprType SBool -> return [WatConst (LitI32 (if val then 1 else 0))]
+    | otherwise -> error $ "Unsupported literal type for WASM compilation: " <> show base.exprType
+compileExpr (Exists (ExprIdent (IdentExpr _ name))) =
+  do
+    env <- get
+    case Map.lookup name env.localMap of
+      Just (Left watTy) -> return [WatLocalGet name watTy]
+      Just (Right funcName) -> return [WatRef funcName]
+      Nothing -> error $ "Unbound identifier: " <> show name
+compileExpr (Exists (ExprBinary (BinaryExpr _ op e1 e2))) =
+  do
+    watE1 <- compileExpr (Exists e1)
+    watE2 <- compileExpr (Exists e2)
+    let watOp = case op of
+          AddInt -> I32Add
+          SubInt -> I32Sub
+          MulInt -> I32Mul
+          DivInt -> I32DivS
+          EqInt -> I32Eq
+          NeInt -> I32Ne
+          AddDouble -> F32Add
+          SubDouble -> F32Sub
+          MulDouble -> F32Mul
+          DivDouble -> F32Div
+          EqDouble -> F32Eq
+          NeDouble -> F32Ne
+          AndBool -> I32And
+          OrBool -> I32Or
+          _ -> error $ "Unsupported binary op for WAT: " <> show op
+    return (watE1 ++ watE2 ++ [WatOp watOp []])
+compileExpr (Exists (ExprLet (LetExpr _ bindings body))) =
+  do
+    initExprsList <- mapM compileLetBinding bindings
+    let initExprs = concat initExprsList -- Flatten the list of lists of expressions
+    bodyExprs <- compileExpr (Exists body)
+    return (initExprs ++ bodyExprs)
+compileExpr (Exists (ExprIf (IfExpr _ cond thenExpr elseExpr))) =
+  do
+    condWat <- compileExpr (Exists cond)
+    let condExpr = case condWat of
+          [c] -> c
+          _ -> error "Conditional expression did not compile to a single WAT expression."
+    thenWat <- compileExpr (Exists thenExpr)
+    elseWat <- compileExpr (Exists elseExpr)
+    return [WatIf condExpr thenWat (Just elseWat)]
+compileExpr (Exists (ExprApp (AppExpr _ f arg))) =
+  do
+    argWat <- compileExpr (Exists arg)
+    env <- get
+    let funcName = case f of
+          (ExprIdent (IdentExpr _ name)) -> case Map.lookup name env.localMap of
+            Just (Right fn) -> fn
+            _ -> error $ "Unsupported function expression in ExprApp: Expected function alias, got " <> show f
+          _ -> error $ "Unsupported function expression in ExprApp: Expected ExprIdent, got " <> show f
+    return [WatCall funcName argWat]
+compileExpr (Exists (ExprLambda (LambdaExpr _ paramName paramTy body))) =
+  do
+    paramWatTy <- return (termTToWatType (Exists paramTy))
+    funcName <- return ("lambda_" <> pack (show paramWatTy)) -- Generate a unique name
+
+    -- Save current environment and set up new environment for function body
+    originalEnv <- get
+    -- Create a new environment for the function body by extending the original environment
+    -- with the lambda's own parameter. This allows the body to access outer scope variables.
+    let funcEnvForBody = originalEnv {localMap = Map.insert paramName (Left paramWatTy) originalEnv.localMap}
+    put funcEnvForBody
+
+    bodyWat <- compileExpr (Exists body)
+    finalFuncEnv <- get -- Get the environment after compiling body
+
+    -- Restore original environment
+    put originalEnv
+
+    let resultWatTy = termTToWatType (getExprType (Exists body))
+    let funcSig = WatTypeSignature {sigParams = [paramWatTy], sigResults = [resultWatTy]}
+
+    (typeAlias, envWithType) <- return (addFunctionTypeSignature originalEnv funcName funcSig) -- Use originalEnv
+    put envWithType -- Update the main environment with the new type alias
+
+    let lambdaFunc = WatFunction
+          { funcName = funcName,
+            funcTypeAlias = typeAlias,
+            funcParams = [(paramName, paramWatTy)], -- Add the parameter here
+            funcLocals = extractFuncLocals (Map.delete paramName finalFuncEnv.localMap), -- Ensure parameter is not a WAT local
+            funcBody = bodyWat
+          }
+    tell [lambdaFunc] -- Add the new function to the Writer output
+    return [WatRef funcName]
+compileExpr (Exists e) = error $ "Unsupported expression for WAT compilation: " <> show e
+
+-- | Compiles the main Calculator AST to a WAT module
+compileToWasm :: Exists Expr -> WatModule
+compileToWasm (Exists expr) =
+  let (body, finalEnv, newFunctions) = runRWS (compileExpr (Exists expr)) () initialCompileEnv
+      -- Determine the main function\'s result type
+      mainResultType = termTToWatType (getExprType (Exists expr))
+
+      -- Create the main function\'s type signature
+      mainFuncSig = WatTypeSignature {sigParams = [], sigResults = [mainResultType]}
+      (mainTypeAlias, envWithMainType) = addFunctionTypeSignature finalEnv "main" mainFuncSig
+
+      mainFunc = 
+        WatFunction
+          { funcName = "main",
+            funcTypeAlias = mainTypeAlias,
+            funcParams = [], -- Main function has no parameters
+            funcLocals = extractFuncLocals envWithMainType.localMap,
+            funcBody = body
+          }
+      allFunctions = [mainFunc] ++ newFunctions
+      -- Transform the type signatures map to have Text aliases as keys
+      finalTypeSignatures = Map.foldrWithKey (\sig alias acc -> Map.insert alias sig acc) Map.empty envWithMainType.typeSignatures
+   in WatModule {moduleTypes = finalTypeSignatures, moduleFunctions = allFunctions}

--- a/src/Language/Calculator/Wasm/Printer.hs
+++ b/src/Language/Calculator/Wasm/Printer.hs
@@ -1,0 +1,174 @@
+module Language.Calculator.Wasm.Printer
+  (
+    printWatModule,
+  )
+where
+
+import Data.Map qualified as Map
+import Data.Text (Text)
+import Data.Text qualified as T
+import Language.Calculator.Wasm.Types (WatExpr (..), WatFunction (..), WatLit (..), WatModule (..), WatOp (..), WatType (..), WatTypeSignature(..))
+
+-- | Prints a WatType to its WAT string representation
+printWatType :: WatType -> Text
+printWatType I32 = "i32"
+printWatType I64 = "i64"
+printWatType F32 = "f32"
+printWatType F64 = "f64"
+printWatType Void = "(void)"
+printWatType (WatTypeRef name) = "(ref " <> name <> ")"
+
+-- | Prints a WatOp to its WAT string representation
+printWatOp :: WatOp -> Text
+printWatOp I32Add = "i32.add"
+printWatOp I32Sub = "i32.sub"
+printWatOp I32Mul = "i32.mul"
+printWatOp I32DivS = "i32.div_s"
+printWatOp I32Eq = "i32.eq"
+printWatOp I32Ne = "i32.ne"
+printWatOp I32LtS = "i32.lt_s"
+printWatOp I32GtS = "i32.gt_s"
+printWatOp I32And = "i32.and"
+printWatOp I32Or = "i32.or"
+printWatOp I32Xor = "i32.xor"
+printWatOp F32Add = "f32.add"
+printWatOp F32Sub = "f32.sub"
+printWatOp F32Mul = "f32.mul"
+printWatOp F32Div = "f32.div"
+printWatOp F32Eq = "f32.eq"
+printWatOp F32Ne = "f32.ne"
+printWatOp F32Lt = "f32.lt"
+printWatOp F32Gt = "f32.gt"
+printWatOp LocalGet = "local.get"
+printWatOp LocalSet = "local.set"
+printWatOp LocalTee = "local.tee"
+printWatOp If = "if"
+printWatOp Else = "else"
+printWatOp End = "end"
+printWatOp Loop = "loop"
+printWatOp Block = "block"
+printWatOp Br = "br"
+printWatOp BrIf = "br_if"
+printWatOp Call = "call"
+
+-- | Prints a WatExpr to its WAT string representation
+printWatExpr :: Int -> WatExpr -> Text
+printWatExpr indent (WatConst lit) =
+  let prefix = T.pack (replicate indent ' ')
+   in prefix <> case lit of
+        LitI32 val -> "i32.const " <> T.pack (show val)
+        LitI64 val -> "i64.const " <> T.pack (show val)
+        LitF32 val -> "f32.const " <> T.pack (show val)
+        LitF64 val -> "f64.const " <> T.pack (show val)
+printWatExpr indent (WatOp op args) =
+  let argLines = map (printWatExpr (indent + 2)) args
+      argStr = if null argLines then "" else T.intercalate "\n" argLines
+   in T.pack (replicate indent ' ') <> printWatOp op <> (if T.null argStr then "" else "\n" <> argStr)
+printWatExpr indent (WatIf cond thenBranch elseBranch) =
+  let condStr = printWatExpr (indent + 2) cond
+      thenLines = map (printWatExpr (indent + 2)) thenBranch
+      thenStr = if null thenLines then "" else T.intercalate "\n" thenLines
+      elseContent = case elseBranch of
+        Just es ->
+          let esLines = map (printWatExpr (indent + 4)) es
+              esStr = if null esLines then "" else T.intercalate "\n" esLines
+           in "\n" <> T.pack (replicate (indent + 2) ' ') <> "else\n" <> (if T.null esStr then "" else esStr <> "\n")
+        Nothing -> ""
+   in T.pack (replicate indent ' ')
+        <> "(if (result i32)\n"
+        <> condStr
+        <> "\n"
+        <> T.pack (replicate (indent + 2) ' ')
+        <> "(then\n"
+        <> (if T.null thenStr then "" else thenStr <> "\n")
+        <> T.pack (replicate (indent + 2) ' ')
+        <> ")"
+        <> elseContent
+        <> T.pack (replicate indent ' ')
+        <> ")"
+printWatExpr indent (WatBlock label exprs) =
+  let labelStr = maybe "" (("$" <>) . (<> " ")) label
+      exprLines = map (printWatExpr (indent + 2)) exprs
+      exprsStr = if null exprLines then "" else T.intercalate "\n" exprLines
+   in T.pack (replicate indent ' ')
+        <> "(block "
+        <> labelStr
+        <> "\n"
+        <> (if T.null exprsStr then "" else exprsStr <> "\n")
+        <> T.pack (replicate indent ' ')
+        <> ")"
+printWatExpr indent (WatLoop label exprs) =
+  let labelStr = maybe "" (("$" <>) . (<> " ")) label
+      exprLines = map (printWatExpr (indent + 2)) exprs
+      exprsStr = if null exprLines then "" else T.intercalate "\n" exprLines
+   in T.pack (replicate indent ' ')
+        <> "(loop "
+        <> labelStr
+        <> "\n"
+        <> (if T.null exprsStr then "" else exprsStr <> "\n")
+        <> T.pack (replicate indent ' ')
+        <> ")"
+printWatExpr indent (WatCall funcName args) =
+  let argLines = map (printWatExpr (indent + 2)) args
+      argStr = if null argLines then "" else T.intercalate "\n" argLines
+   in T.pack (replicate indent ' ')
+        <> "(call $"
+        <> funcName
+        <> "\n"
+        <> (if T.null argStr then "" else argStr <> "\n")
+        <> T.pack (replicate indent ' ')
+        <> ")"
+printWatExpr indent (WatRef funcName) = T.pack (replicate indent ' ') <> "(ref.func $" <> funcName <> ")"
+printWatExpr indent (WatLocalGet idx _) = T.pack (replicate indent ' ') <> "(local.get $" <> idx <> ")"
+printWatExpr indent (WatLocalSet idx _) = T.pack (replicate indent ' ') <> "(local.set $" <> idx <> ")"
+printWatExpr indent (WatLocalTee idx _) = T.pack (replicate indent ' ') <> "(local.tee $" <> idx <> ")"
+
+-- | Prints a WatFunction to its WAT string representation
+printWatFunction :: Int -> Map.Map Text WatTypeSignature -> WatFunction -> Text
+printWatFunction indent _ func =
+  let nameStr = funcName func
+      typeAlias = funcTypeAlias func
+
+      -- Format parameters
+      paramsStr = T.intercalate " " $ map (("(param $" <>) . (<> ")") . (\(n, t) -> n <> " " <> printWatType t)) (funcParams func)
+
+      localsStr = T.intercalate " " $ map (("(local $" <>) . (<> " ") . (\(n, t) -> n <> " " <> printWatType t)) (funcLocals func)
+      bodyLines = map (printWatExpr (indent + 2)) (funcBody func)
+      bodyContent = if null bodyLines then "" else T.intercalate "\n" bodyLines
+   in T.pack (replicate indent ' ')
+        <> "(func $"
+        <> nameStr
+        <> " (type $"
+        <> typeAlias
+        <> ")"
+        <> (if T.null paramsStr then "" else " " <> paramsStr)
+        <> "\n"
+        <> (if T.null localsStr then "" else T.pack (replicate (indent + 2) ' ') <> localsStr <> "\n")
+        <> (if T.null bodyContent then "" else bodyContent <> "\n")
+        <> T.pack (replicate indent ' ')
+        <> ")"
+
+-- | Prints a WatTypeSignature to its WAT string representation
+printWatTypeSignature :: Int -> Text -> WatTypeSignature -> Text
+printWatTypeSignature indent alias sig =
+  let paramsStr = T.intercalate " " $ map printWatType sig.sigParams
+      resultsStr = T.intercalate " " $ map printWatType sig.sigResults
+   in T.pack (replicate indent ' ')
+        <> "(type $"
+        <> alias
+        <> " (func"
+        <> (if T.null paramsStr then "" else " (param " <> paramsStr <> ")")
+        <> (if T.null resultsStr then "" else " (result " <> resultsStr <> ")")
+        <> "))"
+
+-- | Prints a WatModule to its WAT string representation
+printWatModule :: WatModule -> Text
+printWatModule m =
+  let typeSignaturesList = Map.toList (moduleTypes m)
+      typesStr = T.intercalate "\n" $ map (\(alias, sig) -> printWatTypeSignature 2 alias sig) typeSignaturesList
+      funcs = map (printWatFunction 2 (moduleTypes m)) (moduleFunctions m)
+      funcsStr = if null funcs then "" else T.intercalate "\n" funcs
+   in "(module\n"
+        <> (if T.null typesStr then "" else typesStr <> "\n")
+        <> (if T.null funcsStr then "" else funcsStr <> "\n")
+        <> ")"

--- a/src/Language/Calculator/Wasm/Types.hs
+++ b/src/Language/Calculator/Wasm/Types.hs
@@ -1,0 +1,111 @@
+module Language.Calculator.Wasm.Types (
+    WatType(..),
+    WatExpr(..),
+    WatOp(..),
+    WatModule(..),
+    WatFunction(..),
+    WatLit(..),
+    WatTypeSignature(..)
+) where
+
+import Data.Text (Text)
+import qualified Data.Map as Map
+
+-- | Represents WASM value types
+data WatType
+  = I32    -- ^ 32-bit integer
+  | I64    -- ^ 64-bit integer
+  | F32    -- ^ 32-bit float
+  | F64    -- ^ 64-bit float
+  | Void   -- ^ Represents no value (for functions returning nothing)
+  | WatTypeRef Text -- ^ Reference to a function (by name or index)
+  deriving (Show, Eq, Ord)
+
+-- | Represents WASM literal values
+data WatLit
+  = LitI32 Integer    -- ^ 32-bit integer literal
+  | LitI64 Integer    -- ^ 64-bit integer literal
+  | LitF32 Float    -- ^ 32-bit float literal
+  | LitF64 Double   -- ^ 64-bit float literal
+  deriving (Show, Eq)
+
+-- | Represents WASM operations
+data WatOp
+  -- Integer operations
+  = I32Add
+  | I32Sub
+  | I32Mul
+  | I32DivS -- ^ Signed division
+  | I32Eq
+  | I32Ne
+  | I32LtS  -- ^ Signed less than
+  | I32GtS  -- ^ Signed greater than
+  | I32And
+  | I32Or
+  | I32Xor
+
+  -- Float operations
+  | F32Add
+  | F32Sub
+  | F32Mul
+  | F32Div
+  | F32Eq
+  | F32Ne
+  | F32Lt
+  | F32Gt
+
+  -- Generic operations
+  | LocalGet  -- ^ Get local variable
+  | LocalSet  -- ^ Set local variable
+  | LocalTee  -- ^ Set local variable and push value
+
+  -- Control flow
+  | If
+  | Else
+  | End
+  | Loop
+  | Block
+  | Br    -- ^ Branch
+  | BrIf  -- ^ Branch if true
+  | Call  -- ^ Call function
+
+  deriving (Show, Eq)
+
+-- | Represents a WASM expression (instruction or sequence of instructions)
+data WatExpr
+  = WatConst WatLit      -- ^ WASM literal constant
+  | WatOp WatOp [WatExpr]      -- ^ Operation with arguments
+  | WatIf WatExpr [WatExpr] (Maybe [WatExpr]) -- ^ If expression: condition, then-branch, optional else-branch
+  | WatBlock (Maybe Text) [WatExpr] -- ^ Block expression with optional label
+  | WatLoop (Maybe Text) [WatExpr] -- ^ Loop expression with optional label
+  | WatCall Text [WatExpr]       -- ^ Function call with name and arguments
+  | WatLocalGet Text WatType      -- ^ Get local variable by name and type
+  | WatLocalSet Text WatType      -- ^ Set local variable by name and type (value from stack)
+  | WatLocalTee Text WatType      -- ^ Set local variable by name and push value (value from stack)
+  | WatRef Text                 -- ^ Reference to a defined function
+
+  deriving (Show, Eq)
+
+-- Represents a WASM function type signature
+data WatTypeSignature = WatTypeSignature
+  { sigParams :: [WatType],
+    sigResults :: [WatType]
+  }
+  deriving (Show, Eq, Ord)
+
+-- | Represents a WASM function
+data WatFunction = WatFunction
+  { funcName :: Text,
+    funcTypeAlias :: Text, -- Reference to a type signature alias in the module's type section
+    funcParams :: [(Text, WatType)], -- New: Function parameters (name and type)
+    funcLocals :: [(Text, WatType)],
+    funcBody :: [WatExpr]
+  }
+  deriving (Show, Eq)
+
+-- | Represents a complete WASM module
+data WatModule = WatModule
+  { moduleTypes :: Map.Map Text WatTypeSignature, -- New: Map of unique function type signatures with aliases
+    moduleFunctions :: [WatFunction]
+  -- Potentially add imports, exports, globals, data segments etc. later
+  } deriving (Show, Eq)


### PR DESCRIPTION
This commit introduces significant changes to the Abstract Syntax Tree (AST) and adds initial support for compiling Calculator programs to WebAssembly Text (WAT).

Key changes include:

- AST Refactoring:
    - Transformed `Expr` data type constructors into individual record types (e.g., `LitExpr`, `IdentExpr`), improving expression structure and encapsulating `SourceToken` and type information within an `ExprBase`.
    - Updated `getExprType` and `show` functions to align with the new AST structure.

- WebAssembly Compiler:
    - Added new modules (`CompileEnv.hs`, `Compiler.hs`, `Printer.hs`, `Types.hs`) under `src/Language/Calculator/Wasm/`.
    - `CompileEnv.hs`: Defines the compilation environment for WAT generation, managing local variables and type signatures.
    - `Compiler.hs`: Implements the core logic for compiling Calculator AST into WAT expressions and functions, including handling literals, identifiers, binary operations, let bindings, conditionals, function applications, and lambda expressions.
    - `Printer.hs`: Provides utilities for pretty-printing the WAT data structures into their textual representation.
    - `Types.hs`: Introduces data types for representing WASM constructs such as `WatType`, `WatExpr`, `WatOp`, `WatModule`, and `WatFunction`.

These changes lay the groundwork for more advanced type checking and enable the generation of WebAssembly output from Calculator programs.